### PR TITLE
chore/migrate-to-swift 3.0-4

### DIFF
--- a/Example/GGNObservable.xcodeproj/project.pbxproj
+++ b/Example/GGNObservable.xcodeproj/project.pbxproj
@@ -147,7 +147,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0810;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
@@ -272,8 +272,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -317,8 +319,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -337,6 +341,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -345,6 +350,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 782CD098FF1BE18BB7D3F265 /* Pods-GGNObservable_Example.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = GGNObservable/Info.plist;
@@ -360,6 +366,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9F6301E3E9CE0DECCBE8CC07 /* Pods-GGNObservable_Example.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = GGNObservable/Info.plist;

--- a/Example/GGNObservable.xcodeproj/project.pbxproj
+++ b/Example/GGNObservable.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0810;
 					};
 				};
 			};
@@ -351,6 +352,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -365,6 +367,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Example/GGNObservable.xcodeproj/project.pbxproj
+++ b/Example/GGNObservable.xcodeproj/project.pbxproj
@@ -358,7 +358,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -374,7 +374,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Example/GGNObservable.xcodeproj/xcshareddata/xcschemes/GGNObservable-Example.xcscheme
+++ b/Example/GGNObservable.xcodeproj/xcshareddata/xcschemes/GGNObservable-Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0810"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/GGNObservable/AppDelegate.swift
+++ b/Example/GGNObservable/AppDelegate.swift
@@ -13,9 +13,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         let rootVC = resolvedVC()
-        let frame = UIScreen.mainScreen().bounds
+        let frame = UIScreen.main.bounds
         window = UIWindow(frame: frame)
         window?.rootViewController = rootVC
         window?.makeKeyAndVisible()

--- a/Example/GGNObservable/ViewController.swift
+++ b/Example/GGNObservable/ViewController.swift
@@ -23,11 +23,11 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .whiteColor()
+        view.backgroundColor = .white
         setupButton()
 
         viewModel.alertOutput.onNext { [weak self] alert in
-            self?.presentViewController(alert, animated: true, completion: nil)
+            self?.present(alert, animated: true, completion: nil)
         }
 
         viewModel.alertOutput.onNext {
@@ -36,8 +36,8 @@ class ViewController: UIViewController {
     }
 
     func setupButton() {
-        let button = UIButton(type: .ContactAdd)
-        button.addTarget(self, action: #selector(addButtonTapped), forControlEvents: .TouchUpInside)
+        let button = UIButton(type: .contactAdd)
+        button.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
         button.center = view.center
         view.addSubview(button)
     }

--- a/Example/GGNObservable/ViewModel.swift
+++ b/Example/GGNObservable/ViewModel.swift
@@ -22,8 +22,8 @@ class ViewModel: ViewModeling {
     let alertOutput = Observable<UIAlertController>()
 
     func addButtonTapped() {
-        let ok = UIAlertAction(title: "Ok", style: .Default, handler: nil)
-        let alert = UIAlertController(title: "Hello, World!", message: nil, preferredStyle: .Alert)
+        let ok = UIAlertAction(title: "Ok", style: .default, handler: nil)
+        let alert = UIAlertController(title: "Hello, World!", message: nil, preferredStyle: .alert)
         alert.addAction(ok)
         alertOutput.emit(alert)
     }

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -280,6 +280,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					AF2796F3D177E43B11A9BF27C9527995 = {
+						LastSwiftMigration = 0810;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -361,6 +366,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -460,6 +466,7 @@
 				PRODUCT_NAME = GGNObservable;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -366,7 +366,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -466,7 +466,7 @@
 				PRODUCT_NAME = GGNObservable;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/GGNObservable/Classes/Observable.swift
+++ b/GGNObservable/Classes/Observable.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// The `GGNObservable` class can be used for simple reactive style programming. This class has a generic type constraint.
-public class Observable<T> {
+open class Observable<T> {
     // MARK: - Initialization
     /**
      Initializes an instance of an `Obersvable` that's constrained to generic type `T`.
@@ -27,7 +27,7 @@ public class Observable<T> {
      - Returns: `Void`
     */
     public typealias Closure = ((T) -> Void)
-    private var closures: [Closure] = []
+    fileprivate var closures: [Closure] = []
 
     // MARK: - Methods
     /**
@@ -37,7 +37,7 @@ public class Observable<T> {
      
      - Example: `viewModel.alertOutput.onNext { [weak self] alert in self?.presentViewController(alert, animated: true, completion: nil) }`
     */
-    public func onNext(perform closure: Closure) {
+    open func onNext(perform closure: @escaping Closure) {
         self.closures.append(closure)
     }
 
@@ -48,7 +48,7 @@ public class Observable<T> {
      
      - Example: `alertOutput.emit(alert)`
     */
-    public func emit(event: T) {
+    open func emit(_ event: T) {
         closures.forEach { emit in
             emit(event)
         }


### PR DESCRIPTION
This PR delivers [this issue](https://github.com/garricn/GGNObservable/issues/4). Namely, it migrates to Swift 3.0.